### PR TITLE
Fix broken markup style inheritance

### DIFF
--- a/commonmark-spannable/src/main/java/org/commonmark/renderer/spannable/SpannableWriter.java
+++ b/commonmark-spannable/src/main/java/org/commonmark/renderer/spannable/SpannableWriter.java
@@ -51,6 +51,10 @@ public class SpannableWriter {
         mSpans.add(span);
     }
 
+    public void addSpans(ArrayList<Object> spans) {
+        mSpans.addAll(spans);
+    }
+
     public void write(String text) {
         SpannableStringBuilder ssb = new SpannableStringBuilder(text);
 


### PR DESCRIPTION
This PR fixes broken style inheritance.
Test cases: 
- `**some _italic_ text and more _italic_**`
- `[link **bold with _italic_**](a.com) with some text after`
- etc. 