### PR TITLE
Add support for markdown strikethrough

### DIFF
--- a/commonmark-spannable/build.gradle
+++ b/commonmark-spannable/build.gradle
@@ -11,5 +11,6 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.3.0'
-    implementation 'org.commonmark:commonmark:0.18.0'
+    implementation 'org.commonmark:commonmark:0.18.2'
+    implementation 'org.commonmark:commonmark-ext-gfm-strikethrough:0.18.2'
 }

--- a/commonmark-spannable/src/main/java/org/commonmark/renderer/spannable/CoreSpannableNodeRenderer.java
+++ b/commonmark-spannable/src/main/java/org/commonmark/renderer/spannable/CoreSpannableNodeRenderer.java
@@ -1,9 +1,11 @@
 package org.commonmark.renderer.spannable;
 
+import org.commonmark.ext.gfm.strikethrough.Strikethrough;
 import org.commonmark.node.AbstractVisitor;
 import org.commonmark.node.BlockQuote;
 import org.commonmark.node.BulletList;
 import org.commonmark.node.Code;
+import org.commonmark.node.CustomNode;
 import org.commonmark.node.Document;
 import org.commonmark.node.Emphasis;
 import org.commonmark.node.FencedCodeBlock;
@@ -37,6 +39,7 @@ import org.commonmark.renderer.spannable.text.style.LinkSpan;
 import org.commonmark.renderer.spannable.text.style.QuoteSpan;
 
 import android.text.TextUtils;
+import android.text.style.StrikethroughSpan;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -78,7 +81,8 @@ public class CoreSpannableNodeRenderer extends AbstractVisitor implements NodeRe
                 Code.class,
                 HtmlInline.class,
                 SoftLineBreak.class,
-                HardLineBreak.class)
+                HardLineBreak.class,
+                Strikethrough.class)
         );
     }
 
@@ -147,6 +151,17 @@ public class CoreSpannableNodeRenderer extends AbstractVisitor implements NodeRe
     public void visit(HardLineBreak hardLineBreak) {
         mSpannableWriter.line();
         visitChildren(hardLineBreak);
+    }
+
+    @Override
+    public void visit(CustomNode customNode) {
+        if (customNode instanceof Strikethrough) {
+            mSpannableWriter.start(StrikethroughSpan.class);
+            visitChildren(customNode);
+            mSpannableWriter.end(StrikethroughSpan.class);
+        } else {
+            visitChildren(customNode);
+        }
     }
 
     @Override

--- a/commonmark-spannable/src/main/java/org/commonmark/renderer/spannable/CoreSpannableProvider.java
+++ b/commonmark-spannable/src/main/java/org/commonmark/renderer/spannable/CoreSpannableProvider.java
@@ -11,6 +11,8 @@ import org.commonmark.renderer.spannable.text.style.OrderedListItemSpan;
 import org.commonmark.renderer.spannable.text.style.QuoteSpan;
 import org.commonmark.renderer.spannable.text.style.UnorderedListItemSpan;
 
+import android.text.style.StrikethroughSpan;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -37,6 +39,7 @@ class CoreSpannableProvider implements SpannableProvider {
                 LinkSpan.class,
                 OrderedListItemSpan.class,
                 QuoteSpan.class,
+                StrikethroughSpan.class,
                 UnorderedListItemSpan.class)
         );
     }
@@ -95,6 +98,10 @@ class CoreSpannableProvider implements SpannableProvider {
                     mProviderContext.getQuoteStripeWidth(),
                     mProviderContext.getQuotePadding()
             );
+        }
+
+        if (StrikethroughSpan.class.equals(spanClass)) {
+            return new StrikethroughSpan();
         }
 
         throw new IllegalArgumentException("unknown spannable: " + spanClass.toString());


### PR DESCRIPTION
Adding support for strikethrough text, as per the [commonmark spec](https://github.com/commonmark/commonmark-java/#strikethrough)

Example

`~~Strikethrough~~` becomes ~~Strikethrough~~